### PR TITLE
Improve compatibility of Dockerfile with other build tools

### DIFF
--- a/FileServer/Dockerfile
+++ b/FileServer/Dockerfile
@@ -1,8 +1,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0.14-alpine3.21 AS app-base
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.407-alpine3.21 AS build
-ARG TARGETARCH
-ARG APP_VERSION
+ARG TARGETARCH APP_VERSION
 WORKDIR /src
 COPY ["Directory.Build.props", "global.json", ".editorconfig", "./"]
 COPY ["FileServer/FileServer.csproj", "FileServer/"]
@@ -13,9 +12,11 @@ COPY ["FileServer/", "FileServer/"]
 RUN dotnet build "FileServer/FileServer.csproj" -a $TARGETARCH -c Release --no-restore
 
 FROM build AS publish
+ARG TARGETARCH APP_VERSION
 RUN dotnet publish "FileServer/FileServer.csproj" -a $TARGETARCH -c Release --no-build -o /app/publish -p:UseAppHost=false
 
 FROM build AS tests
+ARG TARGETARCH APP_VERSION
 COPY ["FileServer.Tests/", "FileServer.Tests/"]
 RUN dotnet build "FileServer.Tests/FileServer.Tests.csproj" -a $TARGETARCH -c Release --no-restore
 RUN dotnet test "FileServer.Tests/FileServer.Tests.csproj" -a $TARGETARCH -c Release --no-build

--- a/FileServer/Dockerfile-simple
+++ b/FileServer/Dockerfile-simple
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0.407-alpine3.21 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish "FileServer/FileServer.csproj" -c Release -o /app/publish -p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.14-alpine3.21 AS app
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=""
+ENV DOTNET_USE_POLLING_FILE_WATCHER=1
+ENV FileServer_SettingsFilePath="/app/settings/appsettings.json"
+ENTRYPOINT ["dotnet", "FileServer.dll"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Settings that can be configured:
 2. ###### Build the container image.
     For example, using docker:
     ```
-    docker build . -f ./FileServer/Dockerfile -t my_file_server:latest
+    docker build . -f ./FileServer/Dockerfile-simple -t my_file_server:latest
     ```
 
 3. ###### Create/prepare the `server certificate` in PEM format.

--- a/commands.txt
+++ b/commands.txt
@@ -2,5 +2,7 @@ openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout cert.key -o
 
 docker build . -f ./FileServer.E2ETests/Dockerfile -t fs_e2etests:latest
 docker build . -f ./FileServer/Dockerfile -t fs_tests:latest --target tests
-docker build . -f ./FileServer/Dockerfile -t fs:latest
+docker build . -f ./FileServer/Dockerfile -t fs:latest --target app --build-arg APP_VERSION=0.0.1 --platform linux/amd64
+
+docker build . -f ./FileServer/Dockerfile-simple -t fs:latest
 docker run --rm -it --name fs -p 127.0.0.1:7443:8443/tcp -v "$pwd\FileServer\bin\settings:/app/settings" -v "$pwd\FileServer\bin\fs_data:/fs_data" fs:latest


### PR DESCRIPTION
Fixes #1 by adding `Dockerfile-simple`, which contains minimal instructions required to build the app.
Reasoning:
+ Old docker build driver and probably some other build tools don't support pre-defined `BUILDPLATFORM` and `TARGETARCH` ARGs, which are the minimum for an adequate multi-platform Dockerfile.
+ It's easier to understand without multi-platform build, extra stages and versioning, which are not needed in the most common case of the basic build of the app.
+ It will also allow to use latest features and syntax in the main Dockerfile without being held back by compatibility with old/other build tools.

This PR also changes the main Dockerfile to explicitly set the ARGs for each stage where they are used.
Reasoning:
+ It's more clear what args are used in each stage.
+ Some container/build engines like podman/buildah don't inherit args from base stages.
