### PR TITLE
build(deps): Update pinned dotnet runtime to 10.0.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(FS_PIN_RUNTIME_VERSION)' == 'true'">
-    <RuntimeFrameworkVersion>10.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>10.0.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes:

* CVE-2026-32178
* CVE-2026-26171
* CVE-2026-32203
* CVE-2026-33116

None of which affect the server, since System.Net.Mail isn't used at all and System.Security.Cryptography.Xml isn't used on untrusted data.

This is only relevant for pre-built artifacts, excluding framework-dependent binaries (building from the source code uses the latest runtime, unless `FS_PIN_RUNTIME_VERSION` is explicitly set).